### PR TITLE
4.5 Userモデルにpasswordカラム追加、user/newにpassword_field追加

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -32,6 +32,6 @@ class UsersController < ApplicationController
   private
 
     def user_params
-      params.require(:user).permit(:name, :email)
+      params.require(:user).permit(:name, :email, :password)
     end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,2 +1,5 @@
 class User < ApplicationRecord
+  validates :name, presence: true
+  validates :email, presence: true, uniqueness: true
+  validates :password, presence: true
 end

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -8,8 +8,8 @@
   <%= f.label :email, "メールアドレス" %>
   <%= f.text_field :email %>
 
-  <%#= f.label :password, "パスワード" %>
-  <%#= f.password_field :password %>
+  <%= f.label :password, "パスワード" %>
+  <%= f.password_field :password %>
 
   <%#= f.label :password_confirmation, "パスワード（確認）" %>
   <%#= f.password_field :password_confirmation %>

--- a/db/migrate/20220620061233_add_column_password_to_users.rb
+++ b/db/migrate/20220620061233_add_column_password_to_users.rb
@@ -1,0 +1,5 @@
+class AddColumnPasswordToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :password, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_18_125543) do
+ActiveRecord::Schema.define(version: 2022_06_20_061233) do
 
   create_table "products", force: :cascade do |t|
     t.string "name"
@@ -26,6 +26,7 @@ ActiveRecord::Schema.define(version: 2022_06_18_125543) do
     t.string "email"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "password"
   end
 
 end


### PR DESCRIPTION
ログイン機能を作る上で、ユーザーのemail,passwordが必須となるので、Userモデルにバリデーションを追加しました。

バリデーションエラーが起こった際にHTML側にエラーメッセージを表示する機能などは未実装です。